### PR TITLE
check existence of window before referencing it to allow mocha tests to pass

### DIFF
--- a/lib/bufferbuilder.js
+++ b/lib/bufferbuilder.js
@@ -33,8 +33,8 @@ binaryFeatures.supportsBinaryWebsockets = (function(){
 
 module.exports.binaryFeatures = binaryFeatures;
 var BlobBuilder = module.exports.BlobBuilder;
-if (window) {
-BlobBuilder = module.exports.BlobBuilder; = window.WebKitBlobBuilder ||
+if (typeof window != 'undefined') {
+BlobBuilder = module.exports.BlobBuilder = window.WebKitBlobBuilder ||
   window.MozBlobBuilder || window.MSBlobBuilder || window.BlobBuilder;
 } 
 

--- a/lib/bufferbuilder.js
+++ b/lib/bufferbuilder.js
@@ -32,8 +32,11 @@ binaryFeatures.supportsBinaryWebsockets = (function(){
 })();
 
 module.exports.binaryFeatures = binaryFeatures;
-var BlobBuilder = module.exports.BlobBuilder = window.WebKitBlobBuilder ||
+var BlobBuilder = module.exports.BlobBuilder;
+if (window) {
+BlobBuilder = module.exports.BlobBuilder; = window.WebKitBlobBuilder ||
   window.MozBlobBuilder || window.MSBlobBuilder || window.BlobBuilder;
+} 
 
 function BufferBuilder(){
   this._pieces = [];


### PR DESCRIPTION
if you do not check that "window" exists, then a mocha test referencing this JS will fail immediately, claiming that "window" is undefined (even though the js-binarypack module is not used - the mere presence of the window.someProperty makes mocha angry).
