### PR TITLE
fix google closures "ERROR: JSC_PARSE_ERROR. Parse error. identifier is a reserved word"

### DIFF
--- a/lib/binarypack.js
+++ b/lib/binarypack.js
@@ -108,9 +108,7 @@ Unpacker.prototype.unpack = function(){
 }
 
 Unpacker.prototype.unpack_uint8 = function(){
-  var byte = this.dataView[this.index] & 0xff;
-  this.index++;
-  return byte;
+  return this.dataView[this.index++] & 0xff;
 };
 
 Unpacker.prototype.unpack_uint16 = function(){


### PR DESCRIPTION
#11 