### PR TITLE
Fix for 'not yet supported' error when packing classes

### DIFF
--- a/lib/binarypack.js
+++ b/lib/binarypack.js
@@ -300,7 +300,7 @@ Packer.prototype.pack = function(value){
         } else {
           this.pack_bin(value.buffer);
         }
-      } else if (constructor == Object){
+      } else if ((constructor == Object)||(constructor.toString().startsWith('class'))){
         this.pack_object(value);
       } else if (constructor == Date){
         this.pack_string(value.toString());


### PR DESCRIPTION
New class behaviors in recent javascript cause a 'type is not yet supported' error when packing instances of class objects that have a constructor that returns _class ClassName_ instead of _Object_.

This fixes (or works around) it by getting a toString() of what the constructor is and seeing if it starts with 'class'.